### PR TITLE
Court publishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,7 @@ gem 'gds-api-adapters', '~> 17.2'
 group :development, :test do
   gem 'rspec-rails', '3.1.0'
 end
+
+group :test do
+  gem 'webmock', '1.20.4'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'rails-api', '0.3.1'
 gem 'logstasher', '0.6.1'
 gem 'unicorn', '4.8.3'
 gem 'airbrake', '4.1.0'
+gem 'gds-api-adapters', '~> 17.2'
 
 group :development, :test do
   gem 'rspec-rails', '3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,11 +28,14 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.6)
     airbrake (4.1.0)
       builder
       multi_json
     arel (5.0.1.20140414130214)
     builder (3.2.2)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     gds-api-adapters (17.2.0)
@@ -104,6 +107,7 @@ GEM
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    safe_yaml (1.0.4)
     sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -122,6 +126,9 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    webmock (1.20.4)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
 
 PLATFORMS
   ruby
@@ -134,3 +141,4 @@ DEPENDENCIES
   rails-api (= 0.3.1)
   rspec-rails (= 3.1.0)
   unicorn (= 4.8.3)
+  webmock (= 1.20.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    PriorityQueue (0.1.2)
     actionmailer (4.1.8)
       actionpack (= 4.1.8)
       actionview (= 4.1.8)
@@ -34,20 +35,34 @@ GEM
     builder (3.2.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
+    gds-api-adapters (17.2.0)
+      link_header
+      lrucache (~> 0.1.1)
+      null_logger
+      plek
+      rack-cache
+      rest-client (~> 1.6.3)
     hike (1.2.3)
     i18n (0.6.11)
     json (1.8.1)
     kgio (2.9.2)
+    link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.6.1)
       logstash-event (~> 1.1.0)
       request_store
+    lrucache (0.1.4)
+      PriorityQueue (~> 0.1.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.4.3)
     minitest (5.4.3)
     multi_json (1.10.1)
+    null_logger (0.0.1)
+    plek (1.9.0)
     rack (1.5.2)
+    rack-cache (1.2)
+      rack (>= 0.4)
     rack-test (0.6.2)
       rack (>= 1.0)
     rails (4.1.8)
@@ -71,6 +86,8 @@ GEM
     raindrops (0.13.0)
     rake (10.4.0)
     request_store (1.1.0)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rspec-core (3.1.7)
       rspec-support (~> 3.1.0)
     rspec-expectations (3.1.2)
@@ -111,6 +128,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 4.1.0)
+  gds-api-adapters (~> 17.2)
   logstasher (= 0.6.1)
   rails (= 4.1.8)
   rails-api (= 0.3.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::API
+
+private
+  def parse_request_body
+    @parsed_request_body = JSON.parse(request.body.read)
+  rescue JSON::ParserError => e
+    message = "Request JSON could not be parsed: #{e.message}"
+    render json: { status: "error", errors: [message] }, status: 400
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,6 @@ private
     @parsed_request_body = JSON.parse(request.body.read)
   rescue JSON::ParserError => e
     message = "Request JSON could not be parsed: #{e.message}"
-    render json: { status: "error", errors: [message] }, status: 400
+    render json: { status: 'error', errors: [message] }, status: 400
   end
 end

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -1,6 +1,34 @@
 class CourtsController < ApplicationController
   def update
     court_body = JSON.parse(request.body.read)
+    publishing_api_body = publishing_api_format(params[:id], court_body)
+
+    CourtsAPI.publishing_api.put_content_item(
+      base_path(court_body),
+      publishing_api_body,
+    )
     render json: {name: court_body["name"]}
+  end
+
+private
+  def base_path(court_body)
+    "/courts/#{court_body["slug"]}"
+  end
+
+  def publishing_api_format(court_id, court_body)
+    name = court_body["name"]
+
+    {
+      "base_path" => base_path(court_body),
+      "content_id" => court_id,
+      "title" => name,
+      "format" => "court",
+      "update_type" => "major",
+      "publishing_app" => "courts-api",
+      "rendering_app" => "courts-frontend",
+      "routes" => [
+        {"path" => base_path(court_body), "type" => "exact"}
+      ]
+    }
   end
 end

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -16,7 +16,10 @@ class CourtsController < ApplicationController
       base_path(court_body),
       publishing_api_body,
     )
-    render json: {name: court_body["name"]}
+    render json: {
+      name: court_body["name"],
+      public_url: (Plek.new.website_uri + base_path(court_body)).to_s
+    }
   end
 
 private

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -31,15 +31,15 @@ private
     name = court_body["name"]
 
     {
-      "base_path" => base_path(court_body),
-      "content_id" => court_id,
-      "title" => name,
-      "format" => "court",
-      "update_type" => "major",
-      "publishing_app" => "courts-api",
-      "rendering_app" => "courts-frontend",
-      "routes" => [
-        {"path" => base_path(court_body), "type" => "exact"}
+      base_path: base_path(court_body),
+      content_id: court_id,
+      title: name,
+      format: "court",
+      update_type: "major",
+      publishing_app: "courts-api",
+      rendering_app: "courts-frontend",
+      routes: [
+        { path: base_path(court_body), type: "exact" }
       ]
     }
   end

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -1,6 +1,11 @@
 class CourtsController < ApplicationController
   def update
-    court_body = JSON.parse(request.body.read)
+    begin
+      court_body = JSON.parse(request.body.read)
+    rescue JSON::ParserError
+      return head :bad_request
+    end
+
     unless court_body['name'].present? && court_body["slug"].present?
       return head :unprocessable_entity
     end

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -1,6 +1,8 @@
 class CourtsController < ApplicationController
   def update
     court_body = JSON.parse(request.body.read)
+    return head :unprocessable_entity unless court_body["slug"].present?
+
     publishing_api_body = publishing_api_format(params[:id], court_body)
 
     CourtsAPI.publishing_api.put_content_item(

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -1,11 +1,7 @@
 class CourtsController < ApplicationController
-  def update
-    begin
-      court_body = JSON.parse(request.body.read)
-    rescue JSON::ParserError
-      return head :bad_request
-    end
+  before_filter :parse_request_body, only: [:update]
 
+  def update
     unless court_body['name'].present? && court_body["slug"].present?
       return head :unprocessable_entity
     end
@@ -23,6 +19,10 @@ class CourtsController < ApplicationController
   end
 
 private
+  def court_body
+    @parsed_request_body
+  end
+
   def base_path(court_body)
     "/courts/#{court_body["slug"]}"
   end

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -1,7 +1,9 @@
 class CourtsController < ApplicationController
   def update
     court_body = JSON.parse(request.body.read)
-    return head :unprocessable_entity unless court_body["slug"].present?
+    unless court_body['name'].present? && court_body["slug"].present?
+      return head :unprocessable_entity
+    end
 
     publishing_api_body = publishing_api_format(params[:id], court_body)
 

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -2,7 +2,7 @@ class CourtsController < ApplicationController
   before_filter :parse_request_body, only: [:update]
 
   def update
-    unless court_body['name'].present? && court_body["slug"].present?
+    unless court_body['name'].present? && court_body['slug'].present?
       return head :unprocessable_entity
     end
 
@@ -13,7 +13,7 @@ class CourtsController < ApplicationController
       publishing_api_body,
     )
     render json: {
-      name: court_body["name"],
+      name: court_body['name'],
       public_url: (Plek.new.website_uri + base_path(court_body)).to_s
     }
   end
@@ -24,22 +24,22 @@ private
   end
 
   def base_path(court_body)
-    "/courts/#{court_body["slug"]}"
+    "/courts/#{court_body['slug']}"
   end
 
   def publishing_api_format(court_id, court_body)
-    name = court_body["name"]
+    name = court_body['name']
 
     {
       base_path: base_path(court_body),
       content_id: court_id,
       title: name,
-      format: "court",
-      update_type: "major",
-      publishing_app: "courts-api",
-      rendering_app: "courts-frontend",
+      format: 'court',
+      update_type: 'major',
+      publishing_app: 'courts-api',
+      rendering_app: 'courts-frontend',
       routes: [
-        { path: base_path(court_body), type: "exact" }
+        { path: base_path(court_body), type: 'exact' }
       ]
     }
   end

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -1,0 +1,6 @@
+class CourtsController < ApplicationController
+  def update
+    court_body = JSON.parse(request.body.read)
+    render json: {name: court_body["name"]}
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,8 @@ require "action_view/railtie"
 Bundler.require(*Rails.groups)
 
 module CourtsAPI
+  mattr_accessor :publishing_api
+
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require "action_view/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module CourtsApi
+module CourtsAPI
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/initializers/publishing_api.rb
+++ b/config/initializers/publishing_api.rb
@@ -1,0 +1,3 @@
+require 'gds_api/publishing_api'
+
+CourtsAPI.publishing_api = GdsApi::PublishingApi.new(Plek.current.find('publishing-api'))

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -16,4 +16,4 @@
 # Using secret_token for rails3 compatibility. Change to secret_key_base
 # to avoid deprecation warning.
 # Can be safely removed in a rails3 api-only application.
-CourtsApi::Application.config.secret_token = '06d5b6bd03dea708f1858637ee724dddab0c660a99252fd06433be1dedd7d82b9e3d723379c4f59961099dd3a19b6d3959875118e61ec8a8d3743f08f1d5c836'
+CourtsAPI::Application.config.secret_token = '06d5b6bd03dea708f1858637ee724dddab0c660a99252fd06433be1dedd7d82b9e3d723379c4f59961099dd3a19b6d3959875118e61ec8a8d3743f08f1d5c836'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   with_options :format => false do |r|
     r.get '/healthcheck', :to => proc { [200, {}, ['OK']] }
+
+    r.resources 'courts', only: :update
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
+ENV['GOVUK_WEBSITE_ROOT'] ||= 'https://www.gov.uk'
 require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,8 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require 'webmock/rspec'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -3,22 +3,22 @@ require 'rails_helper'
 describe 'publishing a court' do
 
   let(:court_json) do
-    {"name" => "Barnsley Squash Court", "slug" => "barnsley-squash-court"}.to_json
+    { name: "Barnsley Squash Court", slug: "barnsley-squash-court" }.to_json
   end
 
   let(:publishing_api_hash) do
     {
-      "base_path" => "/courts/barnsley-squash-court",
-      "content_id" => court_id,
-      "title" => "Barnsley Squash Court",
-      "format" => "court",
-      "update_type" => "major",
-      "publishing_app" => "courts-api",
-      "rendering_app" => "courts-frontend",
-      "routes" => [
+      base_path: "/courts/barnsley-squash-court",
+      content_id: court_id,
+      title: "Barnsley Squash Court",
+      format: "court",
+      update_type: "major",
+      publishing_app: "courts-api",
+      rendering_app: "courts-frontend",
+      routes: [
         {
-          "path" => "/courts/barnsley-squash-court",
-          "type" => "exact",
+          path: "/courts/barnsley-squash-court",
+          type: "exact",
         }
       ]
     }
@@ -59,12 +59,12 @@ describe 'publishing a court' do
   end
 
   it 'requires a name' do
-    put "/courts/#{court_id}", {"slug" => "barnsley-squash-court"}.to_json
+    put "/courts/#{court_id}", { slug: "barnsley-squash-court" }.to_json
     expect(response).to be_unprocessable
   end
 
   it 'requires a slug' do
-    put "/courts/#{court_id}", {"name" => "Barnsley Squash Court"}.to_json
+    put "/courts/#{court_id}", { name: "Barnsley Squash Court" }.to_json
     expect(response).to be_unprocessable
   end
 

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -3,22 +3,22 @@ require 'rails_helper'
 describe 'publishing a court' do
 
   let(:court_json) do
-    { name: "Barnsley Squash Court", slug: "barnsley-squash-court" }.to_json
+    { name: 'Barnsley Squash Court', slug: 'barnsley-squash-court' }.to_json
   end
 
   let(:publishing_api_hash) do
     {
-      base_path: "/courts/barnsley-squash-court",
+      base_path: '/courts/barnsley-squash-court',
       content_id: court_id,
-      title: "Barnsley Squash Court",
-      format: "court",
-      update_type: "major",
-      publishing_app: "courts-api",
-      rendering_app: "courts-frontend",
+      title: 'Barnsley Squash Court',
+      format: 'court',
+      update_type: 'major',
+      publishing_app: 'courts-api',
+      rendering_app: 'courts-frontend',
       routes: [
         {
-          path: "/courts/barnsley-squash-court",
-          type: "exact",
+          path: '/courts/barnsley-squash-court',
+          type: 'exact',
         }
       ]
     }
@@ -37,7 +37,7 @@ describe 'publishing a court' do
 
   it 'sends the court to the publishing API' do
     expect(CourtsAPI.publishing_api).to receive(:put_content_item).with(
-      "/courts/barnsley-squash-court",
+      '/courts/barnsley-squash-court',
       publishing_api_hash
     )
 
@@ -47,24 +47,24 @@ describe 'publishing a court' do
   it 'includes the court name in the response' do
     put "/courts/#{court_id}", court_json
     response_json = JSON.parse(response.body)
-    expect(response_json).to include("name")
-    expect(response_json["name"]).to eq("Barnsley Squash Court")
+    expect(response_json).to include('name')
+    expect(response_json['name']).to eq('Barnsley Squash Court')
   end
 
   it 'includes the published URL in the response' do
     put "/courts/#{court_id}", court_json
     response_json = JSON.parse(response.body)
-    expect(response_json).to include("public_url")
-    expect(response_json["public_url"]).to eq('https://www.gov.uk/courts/barnsley-squash-court')
+    expect(response_json).to include('public_url')
+    expect(response_json['public_url']).to eq('https://www.gov.uk/courts/barnsley-squash-court')
   end
 
   it 'requires a name' do
-    put "/courts/#{court_id}", { slug: "barnsley-squash-court" }.to_json
+    put "/courts/#{court_id}", { slug: 'barnsley-squash-court' }.to_json
     expect(response).to be_unprocessable
   end
 
   it 'requires a slug' do
-    put "/courts/#{court_id}", { name: "Barnsley Squash Court" }.to_json
+    put "/courts/#{court_id}", { name: 'Barnsley Squash Court' }.to_json
     expect(response).to be_unprocessable
   end
 

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'publishing a court' do
+  let(:court_json) {
+    {"name" => "Barnsley Squash Court"}.to_json
+  }
+
+  it 'responds with a success code' do
+    put '/courts/0c833dee-01de-4f4d-9b2e-e7d1b8d76418', court_json
+    expect(response).to be_success
+  end
+
+  it 'includes the court name in the response' do
+    put '/courts/0c833dee-01de-4f4d-9b2e-e7d1b8d76418', court_json
+    response_json = JSON.parse(response.body)
+    expect(response_json).to include("name")
+    expect(response_json["name"]).to eq("Barnsley Squash Court")
+  end
+end

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -51,6 +51,11 @@ describe 'publishing a court' do
     expect(response_json["name"]).to eq("Barnsley Squash Court")
   end
 
+  it 'requires a name' do
+    put "/courts/#{court_id}", {"slug" => "barnsley-squash-court"}.to_json
+    expect(response).to be_unprocessable
+  end
+
   it 'requires a slug' do
     put "/courts/#{court_id}", {"name" => "Barnsley Squash Court"}.to_json
     expect(response).to be_unprocessable

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -32,7 +32,7 @@ describe 'publishing a court' do
 
   it 'responds with a success code' do
     put "/courts/#{court_id}", court_json
-    expect(response).to be_success
+    expect(response).to have_http_status(200)
   end
 
   it 'sends the court to the publishing API' do
@@ -60,16 +60,16 @@ describe 'publishing a court' do
 
   it 'requires a name' do
     put "/courts/#{court_id}", { slug: 'barnsley-squash-court' }.to_json
-    expect(response).to be_unprocessable
+    expect(response).to have_http_status(422)
   end
 
   it 'requires a slug' do
     put "/courts/#{court_id}", { name: 'Barnsley Squash Court' }.to_json
-    expect(response).to be_unprocessable
+    expect(response).to have_http_status(422)
   end
 
   it 'returns 400 for invalid JSON' do
     put "/courts/#{court_id}", '{"trailing": "comma",}'
-    expect(response).to be_bad_request
+    expect(response).to have_http_status(400)
   end
 end

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -60,4 +60,9 @@ describe 'publishing a court' do
     put "/courts/#{court_id}", {"name" => "Barnsley Squash Court"}.to_json
     expect(response).to be_unprocessable
   end
+
+  it 'returns 400 for invalid JSON' do
+    put "/courts/#{court_id}", '{"trailing": "comma",}'
+    expect(response).to be_bad_request
+  end
 end

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -51,6 +51,13 @@ describe 'publishing a court' do
     expect(response_json["name"]).to eq("Barnsley Squash Court")
   end
 
+  it 'includes the published URL in the response' do
+    put "/courts/#{court_id}", court_json
+    response_json = JSON.parse(response.body)
+    expect(response_json).to include("public_url")
+    expect(response_json["public_url"]).to eq('https://www.gov.uk/courts/barnsley-squash-court')
+  end
+
   it 'requires a name' do
     put "/courts/#{court_id}", {"slug" => "barnsley-squash-court"}.to_json
     expect(response).to be_unprocessable

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -1,17 +1,47 @@
 require 'rails_helper'
 
 describe 'publishing a court' do
-  let(:court_json) {
-    {"name" => "Barnsley Squash Court"}.to_json
-  }
+
+  let(:court_json) do
+    {"name" => "Barnsley Squash Court", "slug" => "barnsley-squash-court"}.to_json
+  end
+
+  let(:publishing_api_hash) do
+    {
+      "base_path" => "/courts/barnsley-squash-court",
+      "content_id" => court_id,
+      "title" => "Barnsley Squash Court",
+      "format" => "court",
+      "update_type" => "major",
+      "publishing_app" => "courts-api",
+      "rendering_app" => "courts-frontend",
+      "routes" => [
+        {
+          "path" => "/courts/barnsley-squash-court",
+          "type" => "exact",
+        }
+      ]
+    }
+  end
+
+  let(:court_id) { '0c833dee-01de-4f4d-9b2e-e7d1b8d76418' }
 
   it 'responds with a success code' do
-    put '/courts/0c833dee-01de-4f4d-9b2e-e7d1b8d76418', court_json
+    put "/courts/#{court_id}", court_json
     expect(response).to be_success
   end
 
+  it 'sends the court to the publishing API' do
+    expect(CourtsAPI.publishing_api).to receive(:put_content_item).with(
+      "/courts/barnsley-squash-court",
+      publishing_api_hash
+    )
+
+    put "/courts/#{court_id}", court_json
+  end
+
   it 'includes the court name in the response' do
-    put '/courts/0c833dee-01de-4f4d-9b2e-e7d1b8d76418', court_json
+    put "/courts/#{court_id}", court_json
     response_json = JSON.parse(response.body)
     expect(response_json).to include("name")
     expect(response_json["name"]).to eq("Barnsley Squash Court")

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -26,6 +26,10 @@ describe 'publishing a court' do
 
   let(:court_id) { '0c833dee-01de-4f4d-9b2e-e7d1b8d76418' }
 
+  before :each do
+    allow(CourtsAPI.publishing_api).to receive(:put_content_item)
+  end
+
   it 'responds with a success code' do
     put "/courts/#{court_id}", court_json
     expect(response).to be_success

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -50,4 +50,9 @@ describe 'publishing a court' do
     expect(response_json).to include("name")
     expect(response_json["name"]).to eq("Barnsley Squash Court")
   end
+
+  it 'requires a slug' do
+    put "/courts/#{court_id}", {"name" => "Barnsley Squash Court"}.to_json
+    expect(response).to be_unprocessable
+  end
 end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'healthcheck path' do
   it 'responds with "OK"' do
     get '/healthcheck'
-    expect(response).to be_success
+    expect(response).to have_http_status(200)
     expect(response.body).to eq('OK')
   end
 end


### PR DESCRIPTION
This adds a PUT route to allow a very simple court to be published. It's the minimum possible to send enough to the content-store to enable a frontend app to display the name of the court:
- `400` if request body is invalid JSON
- `422` if name or slug aren't present in the request body
- PUT to the publishing API
- include the published URL and the court's name in the response body

This doesn't:
- check the `Content-Type` or `Accept` headers; that'll take a little refactoring of the specs to use a JSON test helper as we [do for HMRC](https://github.com/alphagov/hmrc-manuals-api/blob/master/spec/support/json_request_helpers.rb#L2-L9)
- return the status code from the publishing API
- handle any errors from the publishing API explicitly
- set the `Location` header (which we should do for a `201`)
- use any authentication
- validate anything more than that `name` and `slug` are present in the request

Rails allows [both PATCH and PUT](http://edgeguides.rubyonrails.org/routing.html#crud-verbs-and-actions) for the `update` action; we probably don't want to support PATCH, but that isn't dealt with here.

The last commit (to use single quotes wherever possible) might be controversial, and can be removed if the rest of the team disagrees with me.
