### PR TITLE
Check Content-Type and Accept headers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,12 @@
 class ApplicationController < ActionController::API
 
 private
+  def check_content_type_header
+    if request.headers['Content-Type'] != 'application/json'
+      render json: { status: 'error', errors: 'Invalid Content-Type header. You must send application/json.' }, status: 415
+    end
+  end
+
   def parse_request_body
     @parsed_request_body = JSON.parse(request.body.read)
   rescue JSON::ParserError => e

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,12 @@ private
     end
   end
 
+  def check_accept_header
+    if request.headers['Accept'] != 'application/json'
+      render json: { status: 'error', errors: 'Invalid Accept header. You must accept application/json.' }, status: 406
+    end
+  end
+
   def parse_request_body
     @parsed_request_body = JSON.parse(request.body.read)
   rescue JSON::ParserError => e

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -1,4 +1,5 @@
 class CourtsController < ApplicationController
+  before_filter :check_content_type_header, only: [:update]
   before_filter :parse_request_body, only: [:update]
 
   def update

--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -1,5 +1,6 @@
 class CourtsController < ApplicationController
   before_filter :check_content_type_header, only: [:update]
+  before_filter :check_accept_header, only: [:update]
   before_filter :parse_request_body, only: [:update]
 
   def update

--- a/config/initializers/disable_params_parser.rb
+++ b/config/initializers/disable_params_parser.rb
@@ -1,0 +1,6 @@
+# We're doing our own JSON parsing, and error handling. Rails by default tries
+# to parse the request body when the Content-Type header is application/json.
+# When given invalid json, it then blows up before even reaching the
+# application, preventing us from handling invalid json gracefully. This
+# disables the default behaviour, allowing us to handle this case ourselves.
+Rails.application.config.middleware.delete "ActionDispatch::ParamsParser"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ require 'webmock/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -77,4 +77,9 @@ describe 'publishing a court' do
     put_json "/courts/#{court_id}", court_hash, { 'Content-Type' => 'application/xml' }
     expect(response).to have_http_status(415)
   end
+
+  it 'returns 406 when the Accept header is not application/json' do
+    put_json "/courts/#{court_id}", court_hash, { 'Accept' => 'application/xml' }
+    expect(response).to have_http_status(406)
+  end
 end

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe 'publishing a court' do
 
-  let(:court_json) do
-    { name: 'Barnsley Squash Court', slug: 'barnsley-squash-court' }.to_json
+  let(:court_hash) do
+    { name: 'Barnsley Squash Court', slug: 'barnsley-squash-court' }
   end
 
   let(:publishing_api_hash) do
@@ -31,7 +31,7 @@ describe 'publishing a court' do
   end
 
   it 'responds with a success code' do
-    put "/courts/#{court_id}", court_json, { 'Content-Type' => 'application/json' }
+    put_json "/courts/#{court_id}", court_hash
     expect(response).to have_http_status(200)
   end
 
@@ -41,40 +41,40 @@ describe 'publishing a court' do
       publishing_api_hash
     )
 
-    put "/courts/#{court_id}", court_json, { 'Content-Type' => 'application/json' }
+    put_json "/courts/#{court_id}", court_hash
   end
 
   it 'includes the court name in the response' do
-    put "/courts/#{court_id}", court_json, { 'Content-Type' => 'application/json' }
+    put_json "/courts/#{court_id}", court_hash
     response_json = JSON.parse(response.body)
     expect(response_json).to include('name')
     expect(response_json['name']).to eq('Barnsley Squash Court')
   end
 
   it 'includes the published URL in the response' do
-    put "/courts/#{court_id}", court_json, { 'Content-Type' => 'application/json' }
+    put_json "/courts/#{court_id}", court_hash
     response_json = JSON.parse(response.body)
     expect(response_json).to include('public_url')
     expect(response_json['public_url']).to eq('https://www.gov.uk/courts/barnsley-squash-court')
   end
 
   it 'requires a name' do
-    put "/courts/#{court_id}", { slug: 'barnsley-squash-court' }.to_json, { 'Content-Type' => 'application/json' }
+    put_json "/courts/#{court_id}", { slug: 'barnsley-squash-court' }
     expect(response).to have_http_status(422)
   end
 
   it 'requires a slug' do
-    put "/courts/#{court_id}", { name: 'Barnsley Squash Court' }.to_json, { 'Content-Type' => 'application/json' }
+    put_json "/courts/#{court_id}", { name: 'Barnsley Squash Court' }
     expect(response).to have_http_status(422)
   end
 
   it 'returns 400 for invalid JSON' do
-    put "/courts/#{court_id}", '{"trailing": "comma",}', { 'Content-Type' => 'application/json' }
+    put_json "/courts/#{court_id}", '{"trailing": "comma",}'
     expect(response).to have_http_status(400)
   end
 
   it 'returns 415 when the Content-Type header is not application/json' do
-    put "/courts/#{court_id}", court_json, { 'Content-Type' => 'application/xml' }
+    put_json "/courts/#{court_id}", court_hash, { 'Content-Type' => 'application/xml' }
     expect(response).to have_http_status(415)
   end
 end

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -31,7 +31,7 @@ describe 'publishing a court' do
   end
 
   it 'responds with a success code' do
-    put "/courts/#{court_id}", court_json
+    put "/courts/#{court_id}", court_json, { 'Content-Type' => 'application/json' }
     expect(response).to have_http_status(200)
   end
 
@@ -41,35 +41,40 @@ describe 'publishing a court' do
       publishing_api_hash
     )
 
-    put "/courts/#{court_id}", court_json
+    put "/courts/#{court_id}", court_json, { 'Content-Type' => 'application/json' }
   end
 
   it 'includes the court name in the response' do
-    put "/courts/#{court_id}", court_json
+    put "/courts/#{court_id}", court_json, { 'Content-Type' => 'application/json' }
     response_json = JSON.parse(response.body)
     expect(response_json).to include('name')
     expect(response_json['name']).to eq('Barnsley Squash Court')
   end
 
   it 'includes the published URL in the response' do
-    put "/courts/#{court_id}", court_json
+    put "/courts/#{court_id}", court_json, { 'Content-Type' => 'application/json' }
     response_json = JSON.parse(response.body)
     expect(response_json).to include('public_url')
     expect(response_json['public_url']).to eq('https://www.gov.uk/courts/barnsley-squash-court')
   end
 
   it 'requires a name' do
-    put "/courts/#{court_id}", { slug: 'barnsley-squash-court' }.to_json
+    put "/courts/#{court_id}", { slug: 'barnsley-squash-court' }.to_json, { 'Content-Type' => 'application/json' }
     expect(response).to have_http_status(422)
   end
 
   it 'requires a slug' do
-    put "/courts/#{court_id}", { name: 'Barnsley Squash Court' }.to_json
+    put "/courts/#{court_id}", { name: 'Barnsley Squash Court' }.to_json, { 'Content-Type' => 'application/json' }
     expect(response).to have_http_status(422)
   end
 
   it 'returns 400 for invalid JSON' do
-    put "/courts/#{court_id}", '{"trailing": "comma",}'
+    put "/courts/#{court_id}", '{"trailing": "comma",}', { 'Content-Type' => 'application/json' }
     expect(response).to have_http_status(400)
+  end
+
+  it 'returns 415 when the Content-Type header is not application/json' do
+    put "/courts/#{court_id}", court_json, { 'Content-Type' => 'application/xml' }
+    expect(response).to have_http_status(415)
   end
 end

--- a/spec/support/json_request_helpers.rb
+++ b/spec/support/json_request_helpers.rb
@@ -2,6 +2,7 @@ module JSONRequestHelper
   def put_json(path, attrs, headers = {})
     default_headers = {
       "CONTENT_TYPE" => "application/json",
+      "ACCEPT" => "application/json",
     }
     put path, attrs.to_json, default_headers.merge(headers)
   end

--- a/spec/support/json_request_helpers.rb
+++ b/spec/support/json_request_helpers.rb
@@ -1,0 +1,10 @@
+module JSONRequestHelper
+  def put_json(path, attrs, headers = {})
+    default_headers = {
+      "CONTENT_TYPE" => "application/json",
+    }
+    put path, attrs.to_json, default_headers.merge(headers)
+  end
+end
+
+RSpec.configuration.include JSONRequestHelper, :type => :request


### PR DESCRIPTION
If the Content-Type and Accept headers are not set to `application/json` on the request, return 415 or 406 respectively, with a helpful error message.
