### PR TITLE
Remove base_path from Publishing API request body

### DIFF
--- a/app/controllers/courts_controller.rb
+++ b/app/controllers/courts_controller.rb
@@ -34,7 +34,6 @@ private
     name = court_body['name']
 
     {
-      base_path: base_path(court_body),
       content_id: court_id,
       title: name,
       format: 'court',

--- a/spec/requests/courts_spec.rb
+++ b/spec/requests/courts_spec.rb
@@ -8,7 +8,6 @@ describe 'publishing a court' do
 
   let(:publishing_api_hash) do
     {
-      base_path: '/courts/barnsley-squash-court',
       content_id: court_id,
       title: 'Barnsley Squash Court',
       format: 'court',


### PR DESCRIPTION
Publishing API currently ignores this field and is about to start rejecting it.
It uses the version in the request URL instead.

See: https://github.com/alphagov/content-store/pull/104
