### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails-api', '0.3.1'
 gem 'logstasher', '0.6.1'
 gem 'unicorn', '4.8.3'
 gem 'airbrake', '4.1.0'
-gem 'gds-api-adapters', '~> 17.2'
+gem 'gds-api-adapters', '20.1.1'
 gem 'gds-sso', '10.0.0'
 gem 'plek', '1.9.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,16 +37,18 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (17.2.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
       rack-cache
-      rest-client (~> 1.6.3)
+      rest-client (~> 1.8.0)
     gds-sso (10.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -57,6 +59,8 @@ GEM
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
     hashie (3.3.2)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
     jwt (1.2.0)
@@ -75,6 +79,7 @@ GEM
     multi_json (1.11.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    netrc (0.10.3)
     null_logger (0.0.1)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
@@ -94,7 +99,7 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     plek (1.9.0)
-    rack (1.5.4)
+    rack (1.5.5)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-cache (1.2)
@@ -122,8 +127,10 @@ GEM
     raindrops (0.13.0)
     rake (10.4.2)
     request_store (1.1.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec-core (3.1.7)
       rspec-support (~> 3.1.0)
     rspec-expectations (3.1.2)
@@ -151,6 +158,9 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -168,7 +178,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 4.1.0)
-  gds-api-adapters (~> 17.2)
+  gds-api-adapters (= 20.1.1)
   gds-sso (= 10.0.0)
   logstasher (= 0.6.1)
   plek (= 1.9.0)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information
